### PR TITLE
Copypastelist.com is no longer operational

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -329,7 +329,7 @@
 - [Styles Directory | Style Stage](https://stylestage.dev/styles/) - Modern CSS Styles
 - [The Whimsical Web](https://whimsical.club/) - A curated list of sites with an extra bit of fun.
 ### July 14, 2020
-- [Copy Paste List](https://copypastelist.com/) - Quick, unformatted, copy and paste-able lists for all your needs.
+- [Copy Paste List](https://copypastelist.co/) - Quick, unformatted, copy and paste-able lists for all your needs.
 ### July 13, 2020
 - [Animate | Keyframes.app](https://keyframes.app/animate/) - Keyframes gives you a visual timeline to help you create, view, and run animations without having to go back and forth between your browser and editor.
 - [Image Extractor](https://extract.pics/) - A free tool to extract, view and download images from websites.


### PR DESCRIPTION
Please replace copypastelist.com with copypastelist.co, they're identical. 